### PR TITLE
fix: Switch incorrect menu order

### DIFF
--- a/src/components/navbar/Navbar.jsx
+++ b/src/components/navbar/Navbar.jsx
@@ -7,8 +7,8 @@ const Menu = () => (
   <>
   <p><a href='#home'>Home</a></p>
   <p><a href='#wgpt3'>What is gpt?</a></p>
-  <p><a href='#possibility'>Open AI</a></p>
   <p><a href='#features'>Case Studies</a></p>
+  <p><a href='#possibility'>Open AI</a></p>
   <p><a href='#blog'>Library</a></p>
   </>
 )


### PR DESCRIPTION
- Switched the order of Case studies and Open AI 